### PR TITLE
update markdown table for display

### DIFF
--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -22,7 +22,7 @@ The example is an Android phone that has a native processing buffer size
 of 192.  Since WebAudio processes 128 frames we have the following behavior:
 
 |iteration | #	number of frames to render |	number of buffers to render |	leftover frames|
-------------------------------------------------------------------------------------------------
+|---|---|---|---|
 |0|	192|	2|	64|
 |1|	192|	1|	0|
 |2|	192|	2|	64|


### PR DESCRIPTION
@rtoy - you showed us this in today's meeting, and it was mentioned the table was broken.  this pr should "fix" it:

https://github.com/skratchdot/web-audio-api/blob/patch-1/explainer/user-selectable-render-size.md